### PR TITLE
 Add GitHub URL input for GPU JuptyerLab

### DIFF
--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -96,6 +96,9 @@ except FileNotFoundError:
             cp -r /home/\$NB_USER/usecases ./ &&
             cp -r /home/\$NB_USER/home_page.ipynb ./ &&
             jupyter lab --no-browser --NotebookApp.shutdown_button=True
+        #elif $mode.mode_select == 'github':
+            git clone $mode.github_url &&
+            jupyter lab --no-browser --NotebookApp.shutdown_button=True
         #else:
             #import re
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
@@ -119,9 +122,13 @@ except FileNotFoundError:
         <conditional name="mode">
             <param name="mode_select" type="select" label="Do you already have a notebook?" help="Select a set of default notebooks or load an existing one.">
                 <option value="scratch">Start with default notebooks</option>
+                <option value="github">Start with a GitHub repository</option>
                 <option value="previous">Load an existing notebook</option>
             </param>
             <when value="scratch"/>
+            <when value="github">
+                <param name="github_url" type="text" value="" label="GitHub URL" optional="False"/>
+            </when>
             <when value="previous">
                 <param name="ipynb" type="data" format="ipynb" label="IPython Notebook" required="true"/>
                 <param name="run_it" type="boolean" truevalue="true" falsevalue="false" label="Execute notebook and return a new one." help="This option is useful in workflows when you just want to execute a notebook and not dive into the webfrontend."/>


### PR DESCRIPTION
The PR adds a text field for accepting GitHub URL to be cloned before the JupyterLab starts. 
It follows from the discussions in the GTN PR: https://github.com/galaxyproject/training-material/pull/4947

Thank you!

--

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
